### PR TITLE
Fix: Node12 Buffer Update

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,12 +85,12 @@ instance.prototype.init_tcp = function() {
 		self.socket.on("iac", function(type, info) {
 			// tell remote we WONT do anything we're asked to DO
 			if (type == 'DO') {
-				self.socket.write(new Buffer([ 255, 252, info ]));
+				self.socket.write(Buffer.from([ 255, 252, info ]));
 			}
 
 			// tell the remote DONT do whatever they WILL offer
 			if (type == 'WILL') {
-				self.socket.write(new Buffer([ 255, 254, info ]));
+				self.socket.write(Buffer.from([ 255, 254, info ]));
 			}
 		});
 	}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"legacy": [
 		"da-share-multiplay"
 	],
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"api_version": "1.0.0",
 	"keywords": [
 		"Software",


### PR DESCRIPTION
Updated uses of the deprecated `new Buffer()` to the Node12 compliant functions `Buffer.from()` and `Buffer.alloc()`.

Changes made following the guidelines of Variant 1 of the NodeJS Buffer constructor deprecation guide  https://nodejs.org/en/docs/guides/buffer-constructor-deprecation/